### PR TITLE
Fix /register endpoint to generate token after creating user

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -9,6 +9,12 @@ book_goals_table = Table('book_goals', Base.metadata,
     Column('goal_id', Integer, ForeignKey('goals.id'), primary_key=True)
 )
 
+# Junction table for the many-to-many relationship between users and goals
+user_goals_table = Table('user_goals', Base.metadata,
+    Column('user_id', Integer, ForeignKey('users.id'), primary_key=True),
+    Column('goal_id', Integer, ForeignKey('goals.id'), primary_key=True)
+)
+
 class User(Base):
     __tablename__ = "users"
     id = Column(Integer, primary_key=True, index=True)
@@ -16,7 +22,7 @@ class User(Base):
     hashed_password = Column(String, nullable=False)
 
     # Relationship to the UserActiveGoal table
-    active_goal = relationship("UserActiveGoal", back_populates="user", uselist=False, cascade="all, delete-orphan")
+    goals = relationship("Goal", secondary=user_goals_table)
 
 class Book(Base):
     __tablename__ = "books"
@@ -38,15 +44,6 @@ class Goal(Base):
 
     # Many-to-many relationship with Book
     books = relationship("Book", secondary=book_goals_table, back_populates="goals")
-
-class UserActiveGoal(Base):
-    __tablename__ = "user_active_goal"
-    user_id = Column(Integer, ForeignKey('users.id'), primary_key=True)
-    goal_id = Column(Integer, ForeignKey('goals.id'))
-
-    # Relationships back to User and Goal
-    user = relationship("User", back_populates="active_goal")
-    goal = relationship("Goal")
 
 
 class Rating(Base):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel, EmailStr, Field, ConfigDict
+from typing import List
 
 # --- Book Schema ---
 class Book(BaseModel):
@@ -19,6 +20,14 @@ class Goal(BaseModel):
     
     id: int
     name: str
+
+# Schema for SETTING or REPLACING the user's goals with a list
+class UserGoalsUpdate(BaseModel):
+    goal_ids: List[int]
+
+# Schema for ADDING a single goal
+class UserGoalAdd(BaseModel):
+    goal_id: int
 
 # --- Ratings Schema ---
 class RatingCreate(BaseModel):

--- a/frontend/src/pages/GoalsPage.jsx
+++ b/frontend/src/pages/GoalsPage.jsx
@@ -84,7 +84,7 @@ const GoalsPage = () => {
       return;
     }
     setSaving(true);
-    const result = await goalsAPI.selectGoals(selectedGoals); // Note: plural 'selectGoals'
+    const result = await goalsAPI.setGoals(selectedGoals);
     if (result.success) {
       updateUserGoals();
       toast.success('Your goals have been saved!');

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -26,6 +26,9 @@ export const authAPI = {
   register: async (email, password) => {
     try {
       const response = await api.post('/register', { email, password });
+      if (response.data.access_token) {
+        localStorage.setItem('nextread_token', response.data.access_token);
+      }
       return { success: true, data: response.data };
     } catch (error) {
       return {
@@ -75,15 +78,41 @@ export const goalsAPI = {
     }
   },
 
-  selectGoal: async (goalId) => {
+  // Function to SET/REPLACE all user goals with a list (uses PUT)
+  setGoals: async (goalIds) => {
     try {
-      // Corrected to use request body as per latest backend changes
-      const response = await api.post(`/users/me/goal`, { goal_id: goalId });
+      const response = await api.put(`/users/me/goals`, { goal_ids: goalIds });
       return { success: true, data: response.data };
     } catch (error) {
       return {
         success: false,
-        error: error.response?.data?.detail || 'Failed to select goal'
+        error: error.response?.data?.detail || 'Failed to save goals'
+      };
+    }
+  },
+
+  // Function to ADD a single goal (uses POST)
+  addGoal: async (goalId) => {
+    try {
+      const response = await api.post(`/users/me/goals`, { goal_id: goalId });
+      return { success: true, data: response.data };
+    } catch (error) {
+      return {
+        success: false,
+        error: error.response?.data?.detail || 'Failed to add goal'
+      };
+    }
+  },
+
+  // Function to DELETE a single goal (uses DELETE)
+  deleteGoal: async (goalId) => {
+    try {
+      const response = await api.delete(`/users/me/goals/${goalId}`);
+      return { success: true, data: response.data };
+    } catch (error) {
+      return {
+        success: false,
+        error: error.response?.data?.detail || 'Failed to delete goal'
       };
     }
   },


### PR DESCRIPTION
- Corrected the order in the /register endpoint: the new user is now created
  before generating the JWT token and then allowing to set goals.
- Previously, db_user was None when creating the token, causing a
  'NoneType' AttributeError.
- Now, token generation uses the newly created user's email.
- Ensures proper response structure with access_token and token_type.